### PR TITLE
Remove potential *.example.elm file in a practice exercise dir

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -19,6 +19,7 @@ export PATH=/opt/representer/bin:${PATH}
 # Removing comments
 echo "Removing comments"
 cd $WORK_DIR/src
+rm -f *.example.elm # for practice
 elm-strip-comments --replace *.elm
 
 # Running elm-format


### PR DESCRIPTION
This is a small adjustment to easily try the representer on `exercises/practice/*` directories.