### PR TITLE
Restore docker cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32 # 1.1.1
 
+      - name: Cache Docker layers
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # 2.1.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to DockerHub
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # 1.8.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,35 @@ jobs:
 
       - name: Check formatting
         run: elm-format src --validate
+
+  check-docker:
+    name: Check the docker container is built successfully
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32 # 1.1.1
+
+      - name: Cache Docker layers
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # 2.1.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        uses: docker/build-push-action@0db984c1826869dcd0740ff26ff75ff543238fd9 # 2.2.2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: |
+            ${{ github.event.repository.full_name }}:latest
+            ${{ github.event.repository.full_name }}:${{ github.sha }}
+            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:production
+            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -1,19 +1,5 @@
 # Elm Representer
 
-TODO: restore caching to docker image in github actions
-
-```
- - name: Cache Docker layers
-        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # 2.1.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-```
-
-[![ceddlyburge](https://circleci.com/gh/ceddlyburge/elm-representer.svg?style=svg)](https://circleci.com/gh/ceddlyburge/elm-representer)
-
 This outputs a normalized representation of Elm Code, to make automated analysis easier within Exercism.
 
 Thanks to [Elm Platform Worker Example](https://github.com/jxxcarlson/elm-platform-worker-example) for the initial template.


### PR DESCRIPTION
The docker image creation was still failing when run on main without the cache, although it passed on the branch.

I'm not sure why this is, but a job for another day, so restoring the cache as it didn't seem to be the problem