### PR TITLE
Fix copying of src/main.js after compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,5 @@ jobs:
           tags: |
             ${{ github.event.repository.full_name }}:latest
             ${{ github.event.repository.full_name }}:${{ github.sha }}
-            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:production
-            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN npm ci \
 # Compile the elm code for the representer
 COPY src/*.elm src/
 COPY elm.json ./
-RUN npm run make
+RUN npm run make && cp src/main.js bin/
 
 # Pack together things to copy to the runner container into bin/
-COPY bin/run.sh src/cli.js src/main.js bin/
+COPY bin/run.sh src/cli.js bin/
 
 # Lightweight runner container
 FROM node:lts-alpine


### PR DESCRIPTION
So I was copying the src/main.js file from the repo on the disk instead of from the build artifact of elm compilation :facepalm: 
This fixes it.