### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Run the tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
 
   format:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.