### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
     name: Run the tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Install elm tools and cache the ELM_HOME directory
-        uses: mpizenberg/elm-tooling-action@v1.2
+        uses: mpizenberg/elm-tooling-action@9938f6852d942f9714cac58761f378bf25881513
         with:
           cache-key: elm-test-${{ hashFiles('elm-tooling.json', 'elm.json') }}
           cache-restore-key: elm-test
@@ -25,10 +25,10 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Install elm tools and cache the ELM_HOME directory
-        uses: mpizenberg/elm-tooling-action@v1.2
+        uses: mpizenberg/elm-tooling-action@9938f6852d942f9714cac58761f378bf25881513
         with:
           cache-key: elm-format-${{ hashFiles('elm-tooling.json') }}
           cache-restore-key: elm-format


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.